### PR TITLE
Functions with parameters use brackets

### DIFF
--- a/lib/hello_plug_worker.ex
+++ b/lib/hello_plug_worker.ex
@@ -1,5 +1,5 @@
 defmodule HelloPlug.Worker do
   def start_link do
-    Plug.Adapters.Cowboy.http HelloPlug.Router, []
+    Plug.Adapters.Cowboy.http(HelloPlug.Router, [])
   end
 end


### PR DESCRIPTION
Always put brackets when functions have parameters
